### PR TITLE
chore: add netlify config for client routing

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+from = "/"
+to = "/"
+status = 200


### PR DESCRIPTION
This commit fixes the 404 error on page refresh in netlify hosting server.